### PR TITLE
Add CI timeout + paths-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,14 @@ name: Build
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 concurrency:
   group: build-${{ github.ref }}
@@ -14,6 +20,7 @@ jobs:
   build_android_app:
     name: Build Android App
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
- Add `timeout-minutes: 20` to the Android build job.
- Add docs `paths-ignore` so README-only commits skip the build.